### PR TITLE
Development scripts proposition

### DIFF
--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -27,7 +27,7 @@ esac
 done
 
 ## Create directories
-mkdir /srv/tfchain /srv/tfchain/chains /srv/tfchain/chains/tfchain_devnet /srv/tfchain/chains/tfchain_devnet/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
+mkdir -p /srv/tfchain /srv/tfchain/chains /srv/tfchain/chains/tfchain_devnet /srv/tfchain/chains/tfchain_devnet/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp

--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -4,13 +4,13 @@ WD=$(pwd)
 
 # Ask user to make system changes
 while true; do
-read -p "This script will make changes to your Linux installation, are you sure you want to proceed? (y/n) " yn
+read -p "This script will make changes to your Linux installation. Do you want to proceed? (y/n) " yn
 case $yn in 
-        [yY] ) echo ok, we will proceed;
+        [yY] ) echo "OK! We will proceed.";
                 break;;
-        [nN] ) echo exiting...;
+        [nN] ) echo "OK! Exiting the script.";
                 exit;;
-        * ) echo invalid response;;
+        * ) echo "Your answer is invalid.";;
 esac
 done
 
@@ -18,16 +18,17 @@ done
 while true; do
 read -p "Do you want to run the prerequisites script? This will prepare your environment to run the Grid backend. (y/n) " yn
 case $yn in 
-        [yY] ) echo ok, we will proceed;
-                sh ../prep-env-prereq.sh;;
-        [nN] ) echo exiting...;
+        [yY] ) echo "OK! We will run the prerequisites script.";
+                sh ../prep-env-prereq.sh
                 break;;
-        * ) echo invalid response;;
+        [nN] ) echo "OK! Moving to the next step...";
+                break;;
+        * ) echo "Your answer is invalid.";;
 esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain /srv/tfchain/chains /srv/tfchain/chains/tfchain_devnet /srv/tfchain/chains/tfchain_devnet/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
+mkdir -p /srv/tfchain/chains/tfchain_devnet/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -27,7 +27,7 @@ esac
 done
 
 ## Create directories
-mkdir /srv/tfchain /srv/tfchain/chains /srv/tfchain/chains/tfchain_mainnet /srv/tfchain/chains/tfchain_mainnet/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
+mkdir -p /srv/tfchain /srv/tfchain/chains /srv/tfchain/chains/tfchain_mainnet /srv/tfchain/chains/tfchain_mainnet/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -4,13 +4,13 @@ WD=$(pwd)
 
 # Ask user to make system changes
 while true; do
-read -p "This script will make changes to your Linux installation, are you sure you want to proceed? (y/n) " yn
+read -p "This script will make changes to your Linux installation. Do you want to proceed? (y/n) " yn
 case $yn in 
-        [yY] ) echo ok, we will proceed;
+        [yY] ) echo "OK! We will proceed.";
                 break;;
-        [nN] ) echo exiting...;
+        [nN] ) echo "OK! Exiting the script.";
                 exit;;
-        * ) echo invalid response;;
+        * ) echo "Your answer is invalid.";;
 esac
 done
 
@@ -18,16 +18,17 @@ done
 while true; do
 read -p "Do you want to run the prerequisites script? This will prepare your environment to run the Grid backend. (y/n) " yn
 case $yn in 
-        [yY] ) echo ok, we will proceed;
-                sh ../prep-env-prereq.sh;;
-        [nN] ) echo exiting...;
+        [yY] ) echo "OK! We will run the prerequisites script.";
+                sh ../prep-env-prereq.sh
                 break;;
-        * ) echo invalid response;;
+        [nN] ) echo "OK! Moving to the next step...";
+                break;;
+        * ) echo "Your answer is invalid.";;
 esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain /srv/tfchain/chains /srv/tfchain/chains/tfchain_mainnet /srv/tfchain/chains/tfchain_mainnet/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
+mkdir -p /srv/tfchain/chains/tfchain_mainnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp

--- a/docker-compose/prep-env-prereq.sh
+++ b/docker-compose/prep-env-prereq.sh
@@ -71,5 +71,6 @@ EOF
     systemctl daemon-reload
     systemctl enable node-exporter
     systemctl start node-exporter
-    systemctl status node-exporter
+    echo "The node-exporter service status is:"
+    systemctl is-active node-exporter
 fi

--- a/docker-compose/prep-env-prereq.sh
+++ b/docker-compose/prep-env-prereq.sh
@@ -73,4 +73,5 @@ EOF
     systemctl start node-exporter
     echo "The node-exporter service status is:"
     systemctl is-active node-exporter
+    echo "End of prerequisites script."
 fi

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -27,7 +27,7 @@ esac
 done
 
 ## Create directories
-mkdir /srv/tfchain /srv/tfchain/chains /srv/tfchain/chains/tfchain_testnet /srv/tfchain/chains/tfchain_testnet/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
+mkdir -p /srv/tfchain /srv/tfchain/chains /srv/tfchain/chains/tfchain_testnet /srv/tfchain/chains/tfchain_testnet/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -4,13 +4,13 @@ WD=$(pwd)
 
 # Ask user to make system changes
 while true; do
-read -p "This script will make changes to your Linux installation, are you sure you want to proceed? (y/n) " yn
+read -p "This script will make changes to your Linux installation. Do you want to proceed? (y/n) " yn
 case $yn in 
-        [yY] ) echo ok, we will proceed;
+        [yY] ) echo "OK! We will proceed.";
                 break;;
-        [nN] ) echo exiting...;
+        [nN] ) echo "OK! Exiting the script.";
                 exit;;
-        * ) echo invalid response;;
+        * ) echo "Your answer is invalid.";;
 esac
 done
 
@@ -18,16 +18,17 @@ done
 while true; do
 read -p "Do you want to run the prerequisites script? This will prepare your environment to run the Grid backend. (y/n) " yn
 case $yn in 
-        [yY] ) echo ok, we will proceed;
-                sh ../prep-env-prereq.sh;;
-        [nN] ) echo exiting...;
+        [yY] ) echo "OK! We will run the prerequisites script.";
+                sh ../prep-env-prereq.sh
                 break;;
-        * ) echo invalid response;;
+        [nN] ) echo "OK! Moving to the next step...";
+                break;;
+        * ) echo "Your answer is invalid.";;
 esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain /srv/tfchain/chains /srv/tfchain/chains/tfchain_testnet /srv/tfchain/chains/tfchain_testnet/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
+mkdir -p /srv/tfchain/chains/tfchain_testnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp


### PR DESCRIPTION
# Propositions

Here are some propositions from when I run the scripts.

- adding -p for mkdir: useful if you run the script and the downloaded stopped in the middle, you simply rerun the script (otherwise, have to delete the directories)
- replaced systemctl status node-exporter with systemctl is-actiave node-exporter: to avoid having to break the script (with ctrl-c) when doing the install script.
- added a break in a case so we don't have an infinite loop
- updated the displayed text