### PR TITLE
Grid Stack docker compose update for dashboard suite flist

### DIFF
--- a/docker-compose/devnet/docker-compose.yml
+++ b/docker-compose/devnet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /mnt/disk/srv/tfchain/:/storage/
+      - /storage/srv/tfchain/:/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:
@@ -25,7 +25,7 @@ services:
       - "--node-key"
       - "${TFCHAIN_NODE_KEY}"
       - "--base-path"
-      - "/mnt/disk/storage"
+      - "/storage"
       - "--chain"
       - "/etc/chainspecs/dev/chainSpecRaw.json"
       - "--port"
@@ -64,7 +64,7 @@ services:
         hard: 82920
     command: start-single-node --insecure --cache=.45 --max-sql-memory=.45
     volumes:
-      - /mnt/disk/srv/indexer/:/cockroach/cockroach-data
+      - /storage/srv/indexer/:/cockroach/cockroach-data
 
   indexer_db-init:
     depends_on:
@@ -150,7 +150,7 @@ services:
 #    ports:
 #      - "5432:5432"
     volumes:
-      - /mnt/disk/srv/processor/:/var/lib/postgresql/data
+      - /storage/srv/processor/:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
@@ -335,6 +335,6 @@ services:
       DOMAIN: ${DOMAIN}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-      - /mnt/disk/srv/caddy/data:/data
-      - /mnt/disk/srv/caddy/config:/config
-      - /mnt/disk/srv/caddy/log:/var/log/caddy
+      - /storage/srv/caddy/data:/data
+      - /storage/srv/caddy/config:/config
+      - /storage/srv/caddy/log:/var/log/caddy

--- a/docker-compose/devnet/docker-compose.yml
+++ b/docker-compose/devnet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /mnt/disk/srv/tfchain/:/mnt/disk/storage/
+      - /mnt/disk/srv/tfchain/:/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:

--- a/docker-compose/devnet/docker-compose.yml
+++ b/docker-compose/devnet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /srv/tfchain/:/storage/
+      - /mnt/disk/srv/tfchain/:/mnt/disk/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:
@@ -25,7 +25,7 @@ services:
       - "--node-key"
       - "${TFCHAIN_NODE_KEY}"
       - "--base-path"
-      - "/storage"
+      - "/mnt/disk/storage"
       - "--chain"
       - "/etc/chainspecs/dev/chainSpecRaw.json"
       - "--port"
@@ -64,7 +64,7 @@ services:
         hard: 82920
     command: start-single-node --insecure --cache=.45 --max-sql-memory=.45
     volumes:
-      - /srv/indexer/:/cockroach/cockroach-data
+      - /mnt/disk/srv/indexer/:/cockroach/cockroach-data
 
   indexer_db-init:
     depends_on:
@@ -150,7 +150,7 @@ services:
 #    ports:
 #      - "5432:5432"
     volumes:
-      - /srv/processor/:/var/lib/postgresql/data
+      - /mnt/disk/srv/processor/:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
@@ -335,6 +335,6 @@ services:
       DOMAIN: ${DOMAIN}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-      - /srv/caddy/data:/data
-      - /srv/caddy/config:/config
-      - /srv/caddy/log:/var/log/caddy
+      - /mnt/disk/srv/caddy/data:/data
+      - /mnt/disk/srv/caddy/config:/config
+      - /mnt/disk/srv/caddy/log:/var/log/caddy

--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -28,35 +28,35 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_devnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webserver
+mkdir -p /srv/tfchain/chains/tfchain_devnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webpage
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-devnet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webserver/heading.html
-pv tfchain-devnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/tfchain/chains/tfchain_devnet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-devnet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webpage/heading.html
+pv tfchain-devnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/tfchain/chains/tfchain_devnet/db/
 rm tfchain-devnet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-devnet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webserver/heading.html
-pv indexer-devnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-devnet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webpage/heading.html
+pv indexer-devnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/indexer/
 rm indexer-devnet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-devnet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webserver/heading.html
-pv processor-devnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-devnet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webpage/heading.html
+pv processor-devnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/processor/
 rm processor-devnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
 rm -r ~/grid_snapshots_tmp
-zinit stop webserver
-rm /scripts/webserver.sh
-rm /etc/zinit/webserver.yaml
+zinit stop webpage
+rm /scripts/webpage.sh
+rm /etc/zinit/webpage.yaml
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -28,32 +28,32 @@ esac
 done
 
 ## Create directories
-mkdir -p /mnt/disk/srv/tfchain/chains/tfchain_devnet/db /mnt/disk/srv/indexer /mnt/disk/srv/processor /mnt/disk/srv/caddy/data /mnt/disk/srv/caddy/config /mnt/disk/srv/caddy/log /mnt/disk/grid_snapshots_tmp /mnt/disk/tmp/webpage
+mkdir -p /storage/srv/tfchain/chains/tfchain_devnet/db /storage/srv/indexer /storage/srv/processor /storage/srv/caddy/data /storage/srv/caddy/config /storage/srv/caddy/log /storage/grid_snapshots_tmp /storage/tmp/webpage
 
 ## Download snapshots, extract and remove archives
-cd /mnt/disk/grid_snapshots_tmp
+cd /storage/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-devnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f tfchain-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_devnet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-devnet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f tfchain-devnet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/tfchain/chains/tfchain_devnet/db/
 rm tfchain-devnet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-devnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f indexer-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-devnet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f indexer-devnet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/indexer/
 rm indexer-devnet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-devnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f processor-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-devnet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f processor-devnet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/processor/
 rm processor-devnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
-rm -r /mnt/disk/tmp/grid_snapshots_tmp
+rm -r /storage/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
 zinit forget webpage

--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -28,23 +28,35 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_devnet/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
+mkdir -p /srv/tfchain/chains/tfchain_devnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webserver
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsdev/tfchain-devnet-latest.tar.gz .
-pv tfchain-devnet-latest.tar.gz | tar xJ -C /srv/tfchain/chains/tfchain_devnet/db/
+
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-devnet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webserver/heading.html
+pv tfchain-devnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/tfchain/chains/tfchain_devnet/db/
 rm tfchain-devnet-latest.tar.gz
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsdev/indexer-devnet-latest.tar.gz .
-pv indexer-devnet-latest.tar.gz | tar xJ -C /srv/indexer/
+
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-devnet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webserver/heading.html
+pv indexer-devnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/indexer/
 rm indexer-devnet-latest.tar.gz
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsdev/processor-devnet-latest.tar.gz .
-pv processor-devnet-latest.tar.gz | tar xJ -C /srv/processor/
+
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-devnet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webserver/heading.html
+pv processor-devnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/processor/
 rm processor-devnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
 rm -r ~/grid_snapshots_tmp
+zinit stop webserver
+rm /scripts/webserver.sh
+rm /etc/zinit/webserver.yaml
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -53,8 +53,11 @@ rm processor-devnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
-rm -r /mnt/disk/grid_snapshots_tmp
+rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
+zinit stop caddy
+rm /scripts/caddy.sh
+rm /etc/zinit/caddy.yaml
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml
 rm -r mnt/disk/tmp/webpage

--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -28,32 +28,32 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_devnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webpage
+mkdir -p /mnt/disk/srv/tfchain/chains/tfchain_devnet/db /mnt/disk/srv/indexer /mnt/disk/srv/processor /mnt/disk/srv/caddy/data /mnt/disk/srv/caddy/config /mnt/disk/srv/caddy/log /mnt/disk/grid_snapshots_tmp /mnt/disk/tmp/webpage
 
 ## Download snapshots, extract and remove archives
-cd ~/grid_snapshots_tmp
+cd /mnt/disk/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-devnet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webpage/heading.html
-pv tfchain-devnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/tfchain/chains/tfchain_devnet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-devnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv tfchain-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_devnet/db/
 rm tfchain-devnet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-devnet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webpage/heading.html
-pv indexer-devnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-devnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv indexer-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
 rm indexer-devnet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-devnet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webpage/heading.html
-pv processor-devnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-devnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv processor-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
 rm processor-devnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
-rm -r ~/grid_snapshots_tmp
+rm -r /mnt/disk/grid_snapshots_tmp
 zinit stop webpage
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml

--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -56,9 +56,10 @@ cd "$WD"
 rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
-mkdir -p /mnt/disk/zinit_archive
-mv /etc/zinit/caddy.yaml /mnt/disk/zinit_archive/caddy.yaml
-mv /etc/zinit/webpage.yaml /mnt/disk/zinit_archive/webpage.yaml
+zinit forget webpage
+zinit forget caddy
+mv /etc/zinit/caddy.yaml /etc/zinit/caddy.yaml.inactive
+mv /etc/zinit/webpage.yaml /etc/zinit/webpage.yaml.inactive
 rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example

--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -33,13 +33,13 @@ mkdir -p /srv/tfchain/chains/tfchain_devnet/db /srv/indexer /srv/processor /srv/
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsdev/tfchain-devnet-latest.tar.gz .
-tar xvf tfchain-devnet-latest.tar.gz -C /srv/tfchain/chains/tfchain_devnet/db/
+pv tfchain-devnet-latest.tar.gz | tar xJ -C /srv/tfchain/chains/tfchain_devnet/db/
 rm tfchain-devnet-latest.tar.gz
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsdev/indexer-devnet-latest.tar.gz .
-tar xvf indexer-devnet-latest.tar.gz -C /srv/indexer/
+pv indexer-devnet-latest.tar.gz | tar xJ -C /srv/indexer/
 rm indexer-devnet-latest.tar.gz
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsdev/processor-devnet-latest.tar.gz .
-tar xvf processor-devnet-latest.tar.gz -C /srv/processor/
+pv processor-devnet-latest.tar.gz | tar xJ -C /srv/processor/
 rm processor-devnet-latest.tar.gz
 
 ## Clean up 

--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -36,19 +36,19 @@ cd /mnt/disk/grid_snapshots_tmp
 echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-devnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv tfchain-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_devnet/db/
+pv -f tfchain-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_devnet/db/
 rm tfchain-devnet-latest.tar.gz
 
 echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-devnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv indexer-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
+pv -f indexer-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
 rm indexer-devnet-latest.tar.gz
 
 echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-devnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv processor-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
+pv -f processor-devnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
 rm processor-devnet-latest.tar.gz
 
 ## Clean up 

--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -56,10 +56,9 @@ cd "$WD"
 rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
-rm /scripts/caddy.sh
-rm /etc/zinit/caddy.yaml
-rm /scripts/webpage.sh
-rm /etc/zinit/webpage.yaml
+mkdir -p /mnt/disk/zinit_archive
+mv /etc/zinit/caddy.yaml /mnt/disk/zinit_archive/caddy.yaml
+mv /etc/zinit/webpage.yaml /mnt/disk/zinit_archive/webpage.yaml
 rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example

--- a/docker-compose/devnet/install_grid_bknd.sh
+++ b/docker-compose/devnet/install_grid_bknd.sh
@@ -57,6 +57,7 @@ rm -r /mnt/disk/grid_snapshots_tmp
 zinit stop webpage
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml
+rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/devnet/re-sync_processor.sh
+++ b/docker-compose/devnet/re-sync_processor.sh
@@ -3,16 +3,16 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync processor from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir ~/grid_processor_tmp
-cd ~/grid_processor_tmp
+mkdir -p /mnt/disk/grid_processor_tmp
+cd /mnt/disk/grid_processor_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsdev/processor-devnet-latest.tar.gz .
 tar xvf processor-devnet-latest.tar.gz
 rm processor-devnet-latest.tar.gz
 docker stop processor
 docker stop processor_query_node
 docker stop processor_db
-rm -r /srv/processor/*
-mv * /srv/processor/
+rm -r /mnt/disk/srv/processor/*
+mv * /mnt/disk/srv/processor/
 cd "$WD"
 git pull -r
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d processor_db processor processor_query_node
@@ -24,4 +24,4 @@ sleep 30
 docker restart grid_proxy
 
 # Clean up
-rm -r ~/grid_processor_tmp
+rm -r /mnt/disk/grid_processor_tmp

--- a/docker-compose/devnet/re-sync_processor.sh
+++ b/docker-compose/devnet/re-sync_processor.sh
@@ -3,16 +3,16 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync processor from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir -p /mnt/disk/grid_processor_tmp
-cd /mnt/disk/grid_processor_tmp
+mkdir -p /storage/grid_processor_tmp
+cd /storage/grid_processor_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsdev/processor-devnet-latest.tar.gz .
 tar xvf processor-devnet-latest.tar.gz
 rm processor-devnet-latest.tar.gz
 docker stop processor
 docker stop processor_query_node
 docker stop processor_db
-rm -r /mnt/disk/srv/processor/*
-mv * /mnt/disk/srv/processor/
+rm -r /storage/srv/processor/*
+mv * /storage/srv/processor/
 cd "$WD"
 git pull -r
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d processor_db processor processor_query_node
@@ -24,4 +24,4 @@ sleep 30
 docker restart grid_proxy
 
 # Clean up
-rm -r /mnt/disk/grid_processor_tmp
+rm -r /storage/grid_processor_tmp

--- a/docker-compose/mainnet/docker-compose.yml
+++ b/docker-compose/mainnet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /srv/tfchain/:/storage/
+      - /mnt/disk/srv/tfchain/:/mnt/disk/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:
@@ -25,7 +25,7 @@ services:
       - "--node-key"
       - "${TFCHAIN_NODE_KEY}"
       - "--base-path"
-      - "/storage"
+      - "/mnt/disk/storage"
       - "--chain"
       - "/etc/chainspecs/main/chainSpecRaw.json"
       - "--port"
@@ -64,7 +64,7 @@ services:
         hard: 82920
     command: start-single-node --insecure --cache=.45 --max-sql-memory=.45
     volumes:
-      - /srv/indexer/:/cockroach/cockroach-data
+      - /mnt/disk/srv/indexer/:/cockroach/cockroach-data
 
   indexer_db-init:
     depends_on:
@@ -150,7 +150,7 @@ services:
 #    ports:
 #      - "5432:5432"
     volumes:
-      - /srv/processor/:/var/lib/postgresql/data
+      - /mnt/disk/srv/processor/:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
@@ -333,6 +333,6 @@ services:
       DOMAIN: ${DOMAIN}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-      - /srv/caddy/data:/data
-      - /srv/caddy/config:/config
-      - /srv/caddy/log:/var/log/caddy
+      - /mnt/disk/srv/caddy/data:/data
+      - /mnt/disk/srv/caddy/config:/config
+      - /mnt/disk/srv/caddy/log:/var/log/caddy

--- a/docker-compose/mainnet/docker-compose.yml
+++ b/docker-compose/mainnet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /mnt/disk/srv/tfchain/:/mnt/disk/storage/
+      - /mnt/disk/srv/tfchain/:/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:

--- a/docker-compose/mainnet/docker-compose.yml
+++ b/docker-compose/mainnet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /mnt/disk/srv/tfchain/:/storage/
+      - /storage/srv/tfchain/:/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:
@@ -25,7 +25,7 @@ services:
       - "--node-key"
       - "${TFCHAIN_NODE_KEY}"
       - "--base-path"
-      - "/mnt/disk/storage"
+      - "/storage"
       - "--chain"
       - "/etc/chainspecs/main/chainSpecRaw.json"
       - "--port"
@@ -64,7 +64,7 @@ services:
         hard: 82920
     command: start-single-node --insecure --cache=.45 --max-sql-memory=.45
     volumes:
-      - /mnt/disk/srv/indexer/:/cockroach/cockroach-data
+      - /storage/srv/indexer/:/cockroach/cockroach-data
 
   indexer_db-init:
     depends_on:
@@ -150,7 +150,7 @@ services:
 #    ports:
 #      - "5432:5432"
     volumes:
-      - /mnt/disk/srv/processor/:/var/lib/postgresql/data
+      - /storage/srv/processor/:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
@@ -333,6 +333,6 @@ services:
       DOMAIN: ${DOMAIN}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-      - /mnt/disk/srv/caddy/data:/data
-      - /mnt/disk/srv/caddy/config:/config
-      - /mnt/disk/srv/caddy/log:/var/log/caddy
+      - /storage/srv/caddy/data:/data
+      - /storage/srv/caddy/config:/config
+      - /storage/srv/caddy/log:/var/log/caddy

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -28,23 +28,35 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_mainnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
+mkdir -p /srv/tfchain/chains/tfchain_mainnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webserver
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-mainnet-latest.tar.gz .
-pv tfchain-mainnet-latest.tar.gz | tar xJ -C /srv/tfchain/chains/tfchain_mainnet/db/
+
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-mainnet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webserver/heading.html
+pv tfchain-mainnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/tfchain/chains/tfchain_mainnet/db/
 rm tfchain-mainnet-latest.tar.gz
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz .
-pv indexer-mainnet-latest.tar.gz | tar xJ -C /srv/indexer/
+
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webserver/heading.html
+pv indexer-mainnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/indexer/
 rm indexer-mainnet-latest.tar.gz
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz .
-pv processor-mainnet-latest.tar.gz | tar xJ -C /srv/processor/
+
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webserver/heading.html
+pv processor-mainnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/processor/
 rm processor-mainnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
 rm -r ~/grid_snapshots_tmp
+zinit stop webserver
+rm /scripts/webserver.sh
+rm /etc/zinit/webserver.yaml
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -28,32 +28,32 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_mainnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webpage
+mkdir -p /mnt/disk/srv/tfchain/chains/tfchain_mainnet/db /mnt/disk/srv/indexer /mnt/disk/srv/processor /mnt/disk/srv/caddy/data /mnt/disk/srv/caddy/config /mnt/disk/srv/caddy/log /mnt/disk/tmp/grid_snapshots_tmp /mnt/disk/tmp/webpage
 
 ## Download snapshots, extract and remove archives
-cd ~/grid_snapshots_tmp
+cd /mnt/disk/tmp/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-mainnet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webpage/heading.html
-pv tfchain-mainnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/tfchain/chains/tfchain_mainnet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-mainnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv tfchain-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_mainnet/db/
 rm tfchain-mainnet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webpage/heading.html
-pv indexer-mainnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv indexer-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
 rm indexer-mainnet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webpage/heading.html
-pv processor-mainnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv processor-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
 rm processor-mainnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
-rm -r ~/grid_snapshots_tmp
+rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -57,6 +57,7 @@ rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml
+rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -33,13 +33,13 @@ mkdir -p /srv/tfchain/chains/tfchain_mainnet/db /srv/indexer /srv/processor /srv
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-mainnet-latest.tar.gz .
-tar xvf tfchain-mainnet-latest.tar.gz -C /srv/tfchain/chains/tfchain_mainnet/db/
+pv tfchain-mainnet-latest.tar.gz | tar xJ -C /srv/tfchain/chains/tfchain_mainnet/db/
 rm tfchain-mainnet-latest.tar.gz
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz .
-tar xvf indexer-mainnet-latest.tar.gz -C /srv/indexer/
+pv indexer-mainnet-latest.tar.gz | tar xJ -C /srv/indexer/
 rm indexer-mainnet-latest.tar.gz
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz .
-tar xvf processor-mainnet-latest.tar.gz -C /srv/processor/
+pv processor-mainnet-latest.tar.gz | tar xJ -C /srv/processor/
 rm processor-mainnet-latest.tar.gz
 
 ## Clean up 

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -55,6 +55,9 @@ rm processor-mainnet-latest.tar.gz
 cd "$WD"
 rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
+zinit stop caddy
+rm /scripts/caddy.sh
+rm /etc/zinit/caddy.yaml
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml
 rm -r mnt/disk/tmp/webpage

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -28,32 +28,32 @@ esac
 done
 
 ## Create directories
-mkdir -p /mnt/disk/srv/tfchain/chains/tfchain_mainnet/db /mnt/disk/srv/indexer /mnt/disk/srv/processor /mnt/disk/srv/caddy/data /mnt/disk/srv/caddy/config /mnt/disk/srv/caddy/log /mnt/disk/tmp/grid_snapshots_tmp /mnt/disk/tmp/webpage
+mkdir -p /storage/srv/tfchain/chains/tfchain_mainnet/db /storage/srv/indexer /storage/srv/processor /storage/srv/caddy/data /storage/srv/caddy/config /storage/srv/caddy/log /storage/tmp/grid_snapshots_tmp /storage/tmp/webpage
 
 ## Download snapshots, extract and remove archives
-cd /mnt/disk/tmp/grid_snapshots_tmp
+cd /storage/tmp/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-mainnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f tfchain-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_mainnet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-mainnet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f tfchain-mainnet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/tfchain/chains/tfchain_mainnet/db/
 rm tfchain-mainnet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f indexer-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f indexer-mainnet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/indexer/
 rm indexer-mainnet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f processor-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f processor-mainnet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/processor/
 rm processor-mainnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
-rm -r /mnt/disk/tmp/grid_snapshots_tmp
+rm -r /storage/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
 zinit forget webpage

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -56,9 +56,10 @@ cd "$WD"
 rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
-mkdir -p /mnt/disk/zinit_archive
-mv /etc/zinit/caddy.yaml /mnt/disk/zinit_archive/caddy.yaml
-mv /etc/zinit/webpage.yaml /mnt/disk/zinit_archive/webpage.yaml
+zinit forget webpage
+zinit forget caddy
+mv /etc/zinit/caddy.yaml /etc/zinit/caddy.yaml.inactive
+mv /etc/zinit/webpage.yaml /etc/zinit/webpage.yaml.inactive
 rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -36,19 +36,19 @@ cd /mnt/disk/tmp/grid_snapshots_tmp
 echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-mainnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv tfchain-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_mainnet/db/
+pv -f tfchain-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_mainnet/db/
 rm tfchain-mainnet-latest.tar.gz
 
 echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv indexer-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
+pv -f indexer-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
 rm indexer-mainnet-latest.tar.gz
 
 echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv processor-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
+pv -f processor-mainnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
 rm processor-mainnet-latest.tar.gz
 
 ## Clean up 

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -56,10 +56,9 @@ cd "$WD"
 rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
-rm /scripts/caddy.sh
-rm /etc/zinit/caddy.yaml
-rm /scripts/webpage.sh
-rm /etc/zinit/webpage.yaml
+mkdir -p /mnt/disk/zinit_archive
+mv /etc/zinit/caddy.yaml /mnt/disk/zinit_archive/caddy.yaml
+mv /etc/zinit/webpage.yaml /mnt/disk/zinit_archive/webpage.yaml
 rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example

--- a/docker-compose/mainnet/install_grid_bknd.sh
+++ b/docker-compose/mainnet/install_grid_bknd.sh
@@ -28,35 +28,35 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_mainnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webserver
+mkdir -p /srv/tfchain/chains/tfchain_mainnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webpage
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-mainnet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webserver/heading.html
-pv tfchain-mainnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/tfchain/chains/tfchain_mainnet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-mainnet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webpage/heading.html
+pv tfchain-mainnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/tfchain/chains/tfchain_mainnet/db/
 rm tfchain-mainnet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webserver/heading.html
-pv indexer-mainnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webpage/heading.html
+pv indexer-mainnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/indexer/
 rm indexer-mainnet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webserver/heading.html
-pv processor-mainnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webpage/heading.html
+pv processor-mainnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/processor/
 rm processor-mainnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
 rm -r ~/grid_snapshots_tmp
-zinit stop webserver
-rm /scripts/webserver.sh
-rm /etc/zinit/webserver.yaml
+zinit stop webpage
+rm /scripts/webpage.sh
+rm /etc/zinit/webpage.yaml
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/mainnet/re-sync_processor.sh
+++ b/docker-compose/mainnet/re-sync_processor.sh
@@ -3,16 +3,16 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync processor from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir -p /mnt/disk/grid_processor_tmp
-cd /mnt/disk/grid_processor_tmp
+mkdir -p /storage/grid_processor_tmp
+cd /storage/grid_processor_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz .
 tar xvf processor-mainnet-latest.tar.gz
 rm processor-mainnet-latest.tar.gz
 docker stop processor
 docker stop processor_query_node
 docker stop processor_db
-rm -r /mnt/disk/srv/processor/*
-mv * /mnt/disk/srv/processor/
+rm -r /storage/srv/processor/*
+mv * /storage/srv/processor/
 cd "$WD"
 git pull -r
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d processor_db processor processor_query_node
@@ -24,4 +24,4 @@ sleep 30
 docker restart grid_proxy
 
 # Clean up
-rm -r /mnt/disk/grid_processor_tmp
+rm -r /storage/grid_processor_tmp

--- a/docker-compose/mainnet/re-sync_processor.sh
+++ b/docker-compose/mainnet/re-sync_processor.sh
@@ -3,16 +3,16 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync processor from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir ~/grid_processor_tmp
-cd ~/grid_processor_tmp
+mkdir -p /mnt/disk/grid_processor_tmp
+cd /mnt/disk/grid_processor_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-mainnet-latest.tar.gz .
 tar xvf processor-mainnet-latest.tar.gz
 rm processor-mainnet-latest.tar.gz
 docker stop processor
 docker stop processor_query_node
 docker stop processor_db
-rm -r /srv/processor/*
-mv * /srv/processor/
+rm -r /mnt/disk/srv/processor/*
+mv * /mnt/disk/srv/processor/
 cd "$WD"
 git pull -r
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d processor_db processor processor_query_node
@@ -24,4 +24,4 @@ sleep 30
 docker restart grid_proxy
 
 # Clean up
-rm -r ~/grid_processor_tmp
+rm -r /mnt/disk/grid_processor_tmp

--- a/docker-compose/mainnet/resync_indexer.sh
+++ b/docker-compose/mainnet/resync_indexer.sh
@@ -3,13 +3,13 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync indexer from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir -p /mnt/disk/grid_indexer_tmp
-cd /mnt/disk/grid_indexer_tmp
+mkdir -p /storage/grid_indexer_tmp
+cd /storage/grid_indexer_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz .
 tar xvf indexer-mainnet-latest.tar.gz
 rm indexer-mainnet-latest.tar.gz
 docker stop indexer_db
-rm -r /mnt/disk/srv/indexer/*
-mv * /mnt/disk/srv/indexer/
+rm -r /storage/srv/indexer/*
+mv * /storage/srv/indexer/
 cd "$WD"
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d indexer_db

--- a/docker-compose/mainnet/resync_indexer.sh
+++ b/docker-compose/mainnet/resync_indexer.sh
@@ -3,13 +3,13 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync indexer from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir ~/grid_indexer_tmp
-cd ~/grid_indexer_tmp
+mkdir -p /mnt/disk/grid_indexer_tmp
+cd /mnt/disk/grid_indexer_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-mainnet-latest.tar.gz .
 tar xvf indexer-mainnet-latest.tar.gz
 rm indexer-mainnet-latest.tar.gz
 docker stop indexer_db
-rm -r /srv/indexer/*
-mv * /srv/indexer/
+rm -r /mnt/disk/srv/indexer/*
+mv * /mnt/disk/srv/indexer/
 cd "$WD"
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d indexer_db

--- a/docker-compose/prep-env-prereq.sh
+++ b/docker-compose/prep-env-prereq.sh
@@ -5,7 +5,7 @@ RELEASE=node_exporter-${VERSION}.linux-amd64
 
 apt update && apt upgrade -y
 # install troubleshooting tools
-apt install sudo nmon tmux tcpdump iputils-ping net-tools rsync tar -y
+apt install sudo nmon tmux tcpdump iputils-ping net-tools rsync tar pv -y
 
 # install Docker + docker-compose
 apt install ca-certificates curl gnupg lsb-release -y

--- a/docker-compose/qanet/docker-compose.yml
+++ b/docker-compose/qanet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /mnt/disk/srv/tfchain/:/storage/
+      - /storage/srv/tfchain/:/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:
@@ -25,7 +25,7 @@ services:
       - "--node-key"
       - "${TFCHAIN_NODE_KEY}"
       - "--base-path"
-      - "/mnt/disk/storage"
+      - "/storage"
       - "--chain"
       - "/etc/chainspecs/qanet/chainSpecRaw.json"
       - "--port"
@@ -64,7 +64,7 @@ services:
         hard: 82920
     command: start-single-node --insecure --cache=.45 --max-sql-memory=.45
     volumes:
-      - /mnt/disk/srv/indexer/:/cockroach/cockroach-data
+      - /storage/srv/indexer/:/cockroach/cockroach-data
 
   indexer_db-init:
     depends_on:
@@ -150,7 +150,7 @@ services:
 #    ports:
 #      - "5432:5432"
     volumes:
-      - /mnt/disk/srv/processor/:/var/lib/postgresql/data
+      - /storage/srv/processor/:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
@@ -333,6 +333,6 @@ services:
       DOMAIN: ${DOMAIN}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-      - /mnt/disk/srv/caddy/data:/data
-      - /mnt/disk/srv/caddy/config:/config
-      - /mnt/disk/srv/caddy/log:/var/log/caddy
+      - /storage/srv/caddy/data:/data
+      - /storage/srv/caddy/config:/config
+      - /storage/srv/caddy/log:/var/log/caddy

--- a/docker-compose/qanet/docker-compose.yml
+++ b/docker-compose/qanet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /mnt/disk/srv/tfchain/:/mnt/disk/storage/
+      - /mnt/disk/srv/tfchain/:/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:

--- a/docker-compose/qanet/docker-compose.yml
+++ b/docker-compose/qanet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /srv/tfchain/:/storage/
+      - /mnt/disk/srv/tfchain/:/mnt/disk/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:
@@ -25,7 +25,7 @@ services:
       - "--node-key"
       - "${TFCHAIN_NODE_KEY}"
       - "--base-path"
-      - "/storage"
+      - "/mnt/disk/storage"
       - "--chain"
       - "/etc/chainspecs/qanet/chainSpecRaw.json"
       - "--port"
@@ -64,7 +64,7 @@ services:
         hard: 82920
     command: start-single-node --insecure --cache=.45 --max-sql-memory=.45
     volumes:
-      - /srv/indexer/:/cockroach/cockroach-data
+      - /mnt/disk/srv/indexer/:/cockroach/cockroach-data
 
   indexer_db-init:
     depends_on:
@@ -150,7 +150,7 @@ services:
 #    ports:
 #      - "5432:5432"
     volumes:
-      - /srv/processor/:/var/lib/postgresql/data
+      - /mnt/disk/srv/processor/:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
@@ -333,6 +333,6 @@ services:
       DOMAIN: ${DOMAIN}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-      - /srv/caddy/data:/data
-      - /srv/caddy/config:/config
-      - /srv/caddy/log:/var/log/caddy
+      - /mnt/disk/srv/caddy/data:/data
+      - /mnt/disk/srv/caddy/config:/config
+      - /mnt/disk/srv/caddy/log:/var/log/caddy

--- a/docker-compose/qanet/install_grid_bknd.sh
+++ b/docker-compose/qanet/install_grid_bknd.sh
@@ -28,32 +28,32 @@ esac
 done
 
 ## Create directories
-mkdir -p /mnt/disk/srv/tfchain/chains/tfchain_qanet/db /mnt/disk/srv/indexer /mnt/disk/srv/processor /mnt/disk/srv/caddy/data /mnt/disk/srv/caddy/config /mnt/disk/srv/caddy/log /mnt/disk/grid_snapshots_tmp /mnt/disk/tmp/webpage
+mkdir -p /storage/srv/tfchain/chains/tfchain_qanet/db /storage/srv/indexer /storage/srv/processor /storage/srv/caddy/data /storage/srv/caddy/config /storage/srv/caddy/log /storage/grid_snapshots_tmp /storage/tmp/webpage
 
 ## Download snapshots, extract and remove archives
-cd /mnt/disk/grid_snapshots_tmp
+cd /storage/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-qanet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f tfchain-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_qanet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-qanet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f tfchain-qanet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/tfchain/chains/tfchain_qanet/db/
 rm tfchain-qanet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-qanet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f indexer-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-qanet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f indexer-qanet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/indexer/
 rm indexer-qanet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-qanet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f processor-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-qanet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f processor-qanet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/processor/
 rm processor-qanet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
-rm -r /mnt/disk/tmp/grid_snapshots_tmp
+rm -r /storage/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
 zinit forget webpage

--- a/docker-compose/qanet/install_grid_bknd.sh
+++ b/docker-compose/qanet/install_grid_bknd.sh
@@ -53,8 +53,11 @@ rm processor-qanet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
-rm -r /mnt/disk/grid_snapshots_tmp
+rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
+zinit stop caddy
+rm /scripts/caddy.sh
+rm /etc/zinit/caddy.yaml
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml
 rm -r mnt/disk/tmp/webpage

--- a/docker-compose/qanet/install_grid_bknd.sh
+++ b/docker-compose/qanet/install_grid_bknd.sh
@@ -33,13 +33,13 @@ mkdir -p /srv/tfchain/chains/tfchain_qa_net/db /srv/indexer /srv/processor /srv/
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsqa/tfchain-qanet-latest.tar.gz .
-tar xvf tfchain-qanet-latest.tar.gz -C /srv/tfchain/chains/tfchain_qa_net/db/
+pv tfchain-qanet-latest.tar.gz | tar xJ -C /srv/tfchain/chains/tfchain_qanet/db/
 rm tfchain-qanet-latest.tar.gz
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsqa/indexer-qanet-latest.tar.gz .
-tar xvf indexer-qanet-latest.tar.gz -C /srv/indexer/
+pv indexer-qanet-latest.tar.gz | tar xJ -C /srv/indexer/
 rm indexer-qanet-latest.tar.gz
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsqa/processor-qanet-latest.tar.gz .
-tar xvf processor-qanet-latest.tar.gz -C /srv/processor/
+pv processor-qanet-latest.tar.gz | tar xJ -C /srv/processor/
 rm processor-qanet-latest.tar.gz
 
 ## Clean up 

--- a/docker-compose/qanet/install_grid_bknd.sh
+++ b/docker-compose/qanet/install_grid_bknd.sh
@@ -56,9 +56,10 @@ cd "$WD"
 rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
-mkdir -p /mnt/disk/zinit_archive
-mv /etc/zinit/caddy.yaml /mnt/disk/zinit_archive/caddy.yaml
-mv /etc/zinit/webpage.yaml /mnt/disk/zinit_archive/webpage.yaml
+zinit forget webpage
+zinit forget caddy
+mv /etc/zinit/caddy.yaml /etc/zinit/caddy.yaml.inactive
+mv /etc/zinit/webpage.yaml /etc/zinit/webpage.yaml.inactive
 rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example

--- a/docker-compose/qanet/install_grid_bknd.sh
+++ b/docker-compose/qanet/install_grid_bknd.sh
@@ -36,19 +36,19 @@ cd /mnt/disk/grid_snapshots_tmp
 echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-qanet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv tfchain-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_qanet/db/
+pv -f tfchain-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_qanet/db/
 rm tfchain-qanet-latest.tar.gz
 
 echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-qanet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv indexer-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
+pv -f indexer-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
 rm indexer-qanet-latest.tar.gz
 
 echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-qanet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv processor-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
+pv -f processor-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
 rm processor-qanet-latest.tar.gz
 
 ## Clean up 

--- a/docker-compose/qanet/install_grid_bknd.sh
+++ b/docker-compose/qanet/install_grid_bknd.sh
@@ -56,10 +56,9 @@ cd "$WD"
 rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
-rm /scripts/caddy.sh
-rm /etc/zinit/caddy.yaml
-rm /scripts/webpage.sh
-rm /etc/zinit/webpage.yaml
+mkdir -p /mnt/disk/zinit_archive
+mv /etc/zinit/caddy.yaml /mnt/disk/zinit_archive/caddy.yaml
+mv /etc/zinit/webpage.yaml /mnt/disk/zinit_archive/webpage.yaml
 rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example

--- a/docker-compose/qanet/install_grid_bknd.sh
+++ b/docker-compose/qanet/install_grid_bknd.sh
@@ -28,23 +28,35 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_qa_net/db /srv/indexer /srv/processor /srv/caddy /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
+mkdir -p /srv/tfchain/chains/tfchain_qanet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webserver
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsqa/tfchain-qanet-latest.tar.gz .
-pv tfchain-qanet-latest.tar.gz | tar xJ -C /srv/tfchain/chains/tfchain_qanet/db/
+
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-qanet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webserver/heading.html
+pv tfchain-qanet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/tfchain/chains/tfchain_qanet/db/
 rm tfchain-qanet-latest.tar.gz
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsqa/indexer-qanet-latest.tar.gz .
-pv indexer-qanet-latest.tar.gz | tar xJ -C /srv/indexer/
+
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-qanet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webserver/heading.html
+pv indexer-qanet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/indexer/
 rm indexer-qanet-latest.tar.gz
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsqa/processor-qanet-latest.tar.gz .
-pv processor-qanet-latest.tar.gz | tar xJ -C /srv/processor/
+
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-qanet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webserver/heading.html
+pv processor-qanet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/processor/
 rm processor-qanet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
 rm -r ~/grid_snapshots_tmp
+zinit stop webserver
+rm /scripts/webserver.sh
+rm /etc/zinit/webserver.yaml
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/qanet/install_grid_bknd.sh
+++ b/docker-compose/qanet/install_grid_bknd.sh
@@ -28,32 +28,32 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_qanet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webpage
+mkdir -p /mnt/disk/srv/tfchain/chains/tfchain_qanet/db /mnt/disk/srv/indexer /mnt/disk/srv/processor /mnt/disk/srv/caddy/data /mnt/disk/srv/caddy/config /mnt/disk/srv/caddy/log /mnt/disk/grid_snapshots_tmp /mnt/disk/tmp/webpage
 
 ## Download snapshots, extract and remove archives
-cd ~/grid_snapshots_tmp
+cd /mnt/disk/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-qanet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webpage/heading.html
-pv tfchain-qanet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/tfchain/chains/tfchain_qanet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-qanet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv tfchain-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_qanet/db/
 rm tfchain-qanet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-qanet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webpage/heading.html
-pv indexer-qanet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-qanet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv indexer-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
 rm indexer-qanet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-qanet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webpage/heading.html
-pv processor-qanet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-qanet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv processor-qanet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
 rm processor-qanet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
-rm -r ~/grid_snapshots_tmp
+rm -r /mnt/disk/grid_snapshots_tmp
 zinit stop webpage
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml

--- a/docker-compose/qanet/install_grid_bknd.sh
+++ b/docker-compose/qanet/install_grid_bknd.sh
@@ -28,35 +28,35 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_qanet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webserver
+mkdir -p /srv/tfchain/chains/tfchain_qanet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webpage
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-qanet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webserver/heading.html
-pv tfchain-qanet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/tfchain/chains/tfchain_qanet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-qanet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webpage/heading.html
+pv tfchain-qanet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/tfchain/chains/tfchain_qanet/db/
 rm tfchain-qanet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-qanet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webserver/heading.html
-pv indexer-qanet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-qanet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webpage/heading.html
+pv indexer-qanet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/indexer/
 rm indexer-qanet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-qanet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webserver/heading.html
-pv processor-qanet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-qanet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webpage/heading.html
+pv processor-qanet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/processor/
 rm processor-qanet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
 rm -r ~/grid_snapshots_tmp
-zinit stop webserver
-rm /scripts/webserver.sh
-rm /etc/zinit/webserver.yaml
+zinit stop webpage
+rm /scripts/webpage.sh
+rm /etc/zinit/webpage.yaml
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/qanet/install_grid_bknd.sh
+++ b/docker-compose/qanet/install_grid_bknd.sh
@@ -57,6 +57,7 @@ rm -r /mnt/disk/grid_snapshots_tmp
 zinit stop webpage
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml
+rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/qanet/re-sync_processor.sh
+++ b/docker-compose/qanet/re-sync_processor.sh
@@ -3,16 +3,16 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync processor from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir ~/grid_processor_tmp
-cd ~/grid_processor_tmp
+mkdir /mnt/disk/grid_processor_tmp
+cd /mnt/disk/grid_processor_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsqa/processor-qanet-latest.tar.gz .
 tar xvf processor-qanet-latest.tar.gz
 rm processor-qanet-latest.tar.gz
 docker stop processor
 docker stop processor_query_node
 docker stop processor_db
-rm -r /srv/processor/*
-mv * /srv/processor/
+rm -r /mnt/disk/srv/processor/*
+mv * /mnt/disk/srv/processor/
 cd "$WD"
 git pull -r
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d processor_db processor processor_query_node
@@ -24,4 +24,4 @@ sleep 30
 docker restart grid_proxy
 
 # Clean up
-rm -r ~/grid_processor_tmp
+rm -r /mnt/disk/grid_processor_tmp

--- a/docker-compose/qanet/re-sync_processor.sh
+++ b/docker-compose/qanet/re-sync_processor.sh
@@ -3,16 +3,16 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync processor from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir /mnt/disk/grid_processor_tmp
-cd /mnt/disk/grid_processor_tmp
+mkdir /storage/grid_processor_tmp
+cd /storage/grid_processor_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsqa/processor-qanet-latest.tar.gz .
 tar xvf processor-qanet-latest.tar.gz
 rm processor-qanet-latest.tar.gz
 docker stop processor
 docker stop processor_query_node
 docker stop processor_db
-rm -r /mnt/disk/srv/processor/*
-mv * /mnt/disk/srv/processor/
+rm -r /storage/srv/processor/*
+mv * /storage/srv/processor/
 cd "$WD"
 git pull -r
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d processor_db processor processor_query_node
@@ -24,4 +24,4 @@ sleep 30
 docker restart grid_proxy
 
 # Clean up
-rm -r /mnt/disk/grid_processor_tmp
+rm -r /storage/grid_processor_tmp

--- a/docker-compose/testnet/docker-compose.yml
+++ b/docker-compose/testnet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /mnt/disk/srv/tfchain/:/storage/
+      - /storage/srv/tfchain/:/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:
@@ -25,7 +25,7 @@ services:
       - "--node-key"
       - "${TFCHAIN_NODE_KEY}"
       - "--base-path"
-      - "/mnt/disk/storage"
+      - "/storage"
       - "--chain"
       - "/etc/chainspecs/test/chainSpecRaw.json"
       - "--port"
@@ -64,7 +64,7 @@ services:
         hard: 82920
     command: start-single-node --insecure --cache=.45 --max-sql-memory=.45
     volumes:
-      - /mnt/disk/srv/indexer/:/cockroach/cockroach-data
+      - /storage/srv/indexer/:/cockroach/cockroach-data
 
   indexer_db-init:
     depends_on:
@@ -150,7 +150,7 @@ services:
 #    ports:
 #      - "5432:5432"
     volumes:
-      - /mnt/disk/srv/processor/:/var/lib/postgresql/data
+      - /storage/srv/processor/:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
@@ -334,6 +334,6 @@ services:
       DOMAIN: ${DOMAIN}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-      - /mnt/disk/srv/caddy/data:/data
-      - /mnt/disk/srv/caddy/config:/config
-      - /mnt/disk/srv/caddy/log:/var/log/caddy
+      - /storage/srv/caddy/data:/data
+      - /storage/srv/caddy/config:/config
+      - /storage/srv/caddy/log:/var/log/caddy

--- a/docker-compose/testnet/docker-compose.yml
+++ b/docker-compose/testnet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /mnt/disk/srv/tfchain/:/mnt/disk/storage/
+      - /mnt/disk/srv/tfchain/:/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:

--- a/docker-compose/testnet/docker-compose.yml
+++ b/docker-compose/testnet/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   tfchain-public-node:
     container_name: tfchain-public-node
     volumes:
-      - /srv/tfchain/:/storage/
+      - /mnt/disk/srv/tfchain/:/mnt/disk/storage/
     image: ghcr.io/threefoldtech/tfchain:${TFCHAIN_IMG}
     restart: unless-stopped
     networks:
@@ -25,7 +25,7 @@ services:
       - "--node-key"
       - "${TFCHAIN_NODE_KEY}"
       - "--base-path"
-      - "/storage"
+      - "/mnt/disk/storage"
       - "--chain"
       - "/etc/chainspecs/test/chainSpecRaw.json"
       - "--port"
@@ -64,7 +64,7 @@ services:
         hard: 82920
     command: start-single-node --insecure --cache=.45 --max-sql-memory=.45
     volumes:
-      - /srv/indexer/:/cockroach/cockroach-data
+      - /mnt/disk/srv/indexer/:/cockroach/cockroach-data
 
   indexer_db-init:
     depends_on:
@@ -150,7 +150,7 @@ services:
 #    ports:
 #      - "5432:5432"
     volumes:
-      - /srv/processor/:/var/lib/postgresql/data
+      - /mnt/disk/srv/processor/:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASS}
@@ -334,6 +334,6 @@ services:
       DOMAIN: ${DOMAIN}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-      - /srv/caddy/data:/data
-      - /srv/caddy/config:/config
-      - /srv/caddy/log:/var/log/caddy
+      - /mnt/disk/srv/caddy/data:/data
+      - /mnt/disk/srv/caddy/config:/config
+      - /mnt/disk/srv/caddy/log:/var/log/caddy

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -28,35 +28,35 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_testnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webserver
+mkdir -p /srv/tfchain/chains/tfchain_testnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webpage
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-testnet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webserver/heading.html
-pv tfchain-testnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/tfchain/chains/tfchain_testnet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-testnet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webpage/heading.html
+pv tfchain-testnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/tfchain/chains/tfchain_testnet/db/
 rm tfchain-testnet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-testnet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webserver/heading.html
-pv indexer-testnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-testnet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webpage/heading.html
+pv indexer-testnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/indexer/
 rm indexer-testnet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webserver/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-testnet-latest.tar.gz . > /tmp/webserver/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webserver/heading.html
-pv processor-testnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-testnet-latest.tar.gz . > /tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webpage/heading.html
+pv processor-testnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/processor/
 rm processor-testnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
 rm -r ~/grid_snapshots_tmp
-zinit stop webserver
-rm /scripts/webserver.sh
-rm /etc/zinit/webserver.yaml
+zinit stop webpage
+rm /scripts/webpage.sh
+rm /etc/zinit/webpage.yaml
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -28,23 +28,35 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_testnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp
+mkdir -p /srv/tfchain/chains/tfchain_testnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webserver
 
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/tfchain-testnet-latest.tar.gz .
-pv tfchain-testnet-latest.tar.gz | tar xJ -C /srv/tfchain/chains/tfchain_testnet/db/
+
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-testnet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webserver/heading.html
+pv tfchain-testnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/tfchain/chains/tfchain_testnet/db/
 rm tfchain-testnet-latest.tar.gz
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/indexer-testnet-latest.tar.gz .
-pv indexer-testnet-latest.tar.gz | tar xJ -C /srv/indexer/
+
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-testnet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webserver/heading.html
+pv indexer-testnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/indexer/
 rm indexer-testnet-latest.tar.gz
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/processor-testnet-latest.tar.gz .
-pv processor-testnet-latest.tar.gz | tar xJ -C /srv/processor/
+
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webserver/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-testnet-latest.tar.gz . > /tmp/webserver/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webserver/heading.html
+pv processor-testnet-latest.tar.gz 2> /tmp/webserver/log | tar xJ -C /srv/processor/
 rm processor-testnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
 rm -r ~/grid_snapshots_tmp
+zinit stop webserver
+rm /scripts/webserver.sh
+rm /etc/zinit/webserver.yaml
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -53,8 +53,11 @@ rm processor-testnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
-rm -r /mnt/disk/grid_snapshots_tmp
+rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
+zinit stop caddy
+rm /scripts/caddy.sh
+rm /etc/zinit/caddy.yaml
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml
 rm -r mnt/disk/tmp/webpage

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -36,19 +36,19 @@ cd /mnt/disk/grid_snapshots_tmp
 echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-testnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv tfchain-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_testnet/db/
+pv -f tfchain-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_testnet/db/
 rm tfchain-testnet-latest.tar.gz
 
 echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-testnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv indexer-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
+pv -f indexer-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
 rm indexer-testnet-latest.tar.gz
 
 echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-testnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
 echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv processor-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
+pv -f processor-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
 rm processor-testnet-latest.tar.gz
 
 ## Clean up 

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -56,9 +56,10 @@ cd "$WD"
 rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
-mkdir -p /mnt/disk/zinit_archive
-mv /etc/zinit/caddy.yaml /mnt/disk/zinit_archive/caddy.yaml
-mv /etc/zinit/webpage.yaml /mnt/disk/zinit_archive/webpage.yaml
+zinit forget webpage
+zinit forget caddy
+mv /etc/zinit/caddy.yaml /etc/zinit/caddy.yaml.inactive
+mv /etc/zinit/webpage.yaml /etc/zinit/webpage.yaml.inactive
 rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -33,13 +33,13 @@ mkdir -p /srv/tfchain/chains/tfchain_testnet/db /srv/indexer /srv/processor /srv
 ## Download snapshots, extract and remove archives
 cd ~/grid_snapshots_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/tfchain-testnet-latest.tar.gz .
-tar xvf tfchain-testnet-latest.tar.gz -C /srv/tfchain/chains/tfchain_testnet/db/
+pv tfchain-testnet-latest.tar.gz | tar xJ -C /srv/tfchain/chains/tfchain_testnet/db/
 rm tfchain-testnet-latest.tar.gz
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/indexer-testnet-latest.tar.gz .
-tar xvf indexer-testnet-latest.tar.gz -C /srv/indexer/
+pv indexer-testnet-latest.tar.gz | tar xJ -C /srv/indexer/
 rm indexer-testnet-latest.tar.gz
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/processor-testnet-latest.tar.gz .
-tar xvf processor-testnet-latest.tar.gz -C /srv/processor/
+pv processor-testnet-latest.tar.gz | tar xJ -C /srv/processor/
 rm processor-testnet-latest.tar.gz
 
 ## Clean up 

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -28,32 +28,32 @@ esac
 done
 
 ## Create directories
-mkdir -p /mnt/disk/srv/tfchain/chains/tfchain_testnet/db /mnt/disk/srv/indexer /mnt/disk/srv/processor /mnt/disk/srv/caddy/data /mnt/disk/srv/caddy/config /mnt/disk/srv/caddy/log /mnt/disk/grid_snapshots_tmp /mnt/disk/tmp/webpage
+mkdir -p /storage/srv/tfchain/chains/tfchain_testnet/db /storage/srv/indexer /storage/srv/processor /storage/srv/caddy/data /storage/srv/caddy/config /storage/srv/caddy/log /storage/grid_snapshots_tmp /storage/tmp/webpage
 
 ## Download snapshots, extract and remove archives
-cd /mnt/disk/grid_snapshots_tmp
+cd /storage/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-testnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f tfchain-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_testnet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-testnet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f tfchain-testnet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/tfchain/chains/tfchain_testnet/db/
 rm tfchain-testnet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-testnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f indexer-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-testnet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f indexer-testnet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/indexer/
 rm indexer-testnet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-testnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
-pv -f processor-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /storage/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-testnet-latest.tar.gz . > /storage/tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /storage/tmp/webpage/heading.html
+pv -f processor-testnet-latest.tar.gz 2> /storage/tmp/webpage/log | tar xJ -C /storage/srv/processor/
 rm processor-testnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
-rm -r /mnt/disk/tmp/grid_snapshots_tmp
+rm -r /storage/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
 zinit forget webpage

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -56,10 +56,9 @@ cd "$WD"
 rm -r /mnt/disk/tmp/grid_snapshots_tmp
 zinit stop webpage
 zinit stop caddy
-rm /scripts/caddy.sh
-rm /etc/zinit/caddy.yaml
-rm /scripts/webpage.sh
-rm /etc/zinit/webpage.yaml
+mkdir -p /mnt/disk/zinit_archive
+mv /etc/zinit/caddy.yaml /mnt/disk/zinit_archive/caddy.yaml
+mv /etc/zinit/webpage.yaml /mnt/disk/zinit_archive/webpage.yaml
 rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -28,32 +28,32 @@ esac
 done
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_testnet/db /srv/indexer /srv/processor /srv/caddy/data /srv/caddy/config /srv/caddy/log ~/grid_snapshots_tmp /tmp/webpage
+mkdir -p /mnt/disk/srv/tfchain/chains/tfchain_testnet/db /mnt/disk/srv/indexer /mnt/disk/srv/processor /mnt/disk/srv/caddy/data /mnt/disk/srv/caddy/config /mnt/disk/srv/caddy/log /mnt/disk/grid_snapshots_tmp /mnt/disk/tmp/webpage
 
 ## Download snapshots, extract and remove archives
-cd ~/grid_snapshots_tmp
+cd /mnt/disk/grid_snapshots_tmp
 
-echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-testnet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /tmp/webpage/heading.html
-pv tfchain-testnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/tfchain/chains/tfchain_testnet/db/
+echo '<h1>Step 1 of 6: Downloading TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-testnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 2 of 6: Extracting TFChain Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv tfchain-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/tfchain/chains/tfchain_testnet/db/
 rm tfchain-testnet-latest.tar.gz
 
-echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-testnet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /tmp/webpage/heading.html
-pv indexer-testnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/indexer/
+echo '<h1>Step 3 of 6: Downloading Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/indexer-testnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 4 of 6: Extracting Indexer Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv indexer-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/indexer/
 rm indexer-testnet-latest.tar.gz
 
-echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /tmp/webpage/heading.html
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-testnet-latest.tar.gz . > /tmp/webpage/log
-echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /tmp/webpage/heading.html
-pv processor-testnet-latest.tar.gz 2> /tmp/webpage/log | tar xJ -C /srv/processor/
+echo '<h1>Step 5 of 6: Downloading Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/processor-testnet-latest.tar.gz . > /mnt/disk/tmp/webpage/log
+echo '<h1>Step 6 of 6: Extracting Processor Snapshot</h1>' > /mnt/disk/tmp/webpage/heading.html
+pv processor-testnet-latest.tar.gz 2> /mnt/disk/tmp/webpage/log | tar xJ -C /mnt/disk/srv/processor/
 rm processor-testnet-latest.tar.gz
 
 ## Clean up 
 cd "$WD"
-rm -r ~/grid_snapshots_tmp
+rm -r /mnt/disk/grid_snapshots_tmp
 zinit stop webpage
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml

--- a/docker-compose/testnet/install_grid_bknd.sh
+++ b/docker-compose/testnet/install_grid_bknd.sh
@@ -57,6 +57,7 @@ rm -r /mnt/disk/grid_snapshots_tmp
 zinit stop webpage
 rm /scripts/webpage.sh
 rm /etc/zinit/webpage.yaml
+rm -r mnt/disk/tmp/webpage
 
 # Copy Cadyfile from example
 cp Caddyfile-example Caddyfile

--- a/docker-compose/testnet/re-sync_processor.sh
+++ b/docker-compose/testnet/re-sync_processor.sh
@@ -3,16 +3,16 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync processor from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir /mnt/disk/grid_processor_tmp
-cd /mnt/disk/grid_processor_tmp
+mkdir /storage/grid_processor_tmp
+cd /storage/grid_processor_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/processor-testnet-latest.tar.gz .
 tar xvf processor-testnet-latest.tar.gz
 rm processor-testnet-latest.tar.gz
 docker stop processor
 docker stop processor_query_node
 docker stop processor_db
-rm -r /mnt/disk/srv/processor/*
-mv * /mnt/disk/srv/processor/
+rm -r /storage/srv/processor/*
+mv * /storage/srv/processor/
 cd "$WD"
 git pull -r
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d processor_db processor processor_query_node
@@ -24,4 +24,4 @@ sleep 30
 docker restart grid_proxy
 
 # Clean up
-rm -r /mnt/disk/grid_processor_tmp
+rm -r /storage/grid_processor_tmp

--- a/docker-compose/testnet/re-sync_processor.sh
+++ b/docker-compose/testnet/re-sync_processor.sh
@@ -3,16 +3,16 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync processor from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir ~/grid_processor_tmp
-cd ~/grid_processor_tmp
+mkdir /mnt/disk/grid_processor_tmp
+cd /mnt/disk/grid_processor_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/processor-testnet-latest.tar.gz .
 tar xvf processor-testnet-latest.tar.gz
 rm processor-testnet-latest.tar.gz
 docker stop processor
 docker stop processor_query_node
 docker stop processor_db
-rm -r /srv/processor/*
-mv * /srv/processor/
+rm -r /mnt/disk/srv/processor/*
+mv * /mnt/disk/srv/processor/
 cd "$WD"
 git pull -r
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d processor_db processor processor_query_node
@@ -24,4 +24,4 @@ sleep 30
 docker restart grid_proxy
 
 # Clean up
-rm -r ~/grid_processor_tmp
+rm -r /mnt/disk/grid_processor_tmp

--- a/docker-compose/testnet/resync_indexer.sh
+++ b/docker-compose/testnet/resync_indexer.sh
@@ -3,13 +3,13 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync indexer from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir -p /mnt/disk/grid_indexer_tmp
-cd /mnt/disk/grid_indexer_tmp
+mkdir -p /storage/grid_indexer_tmp
+cd /storage/grid_indexer_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/indexer-testnet-latest.tar.gz .
 tar xvf indexer-testnet-latest.tar.gz
 rm indexer-testnet-latest.tar.gz
 docker stop indexer_db
-rm -r /mnt/disk/srv/indexer/*
-mv * /mnt/disk/srv/indexer/
+rm -r /storage/srv/indexer/*
+mv * /storage/srv/indexer/
 cd "$WD"
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d indexer_db

--- a/docker-compose/testnet/resync_indexer.sh
+++ b/docker-compose/testnet/resync_indexer.sh
@@ -3,13 +3,13 @@ WD=$(pwd)
 
 # Upgrade and fully re-sync indexer from block 0
 # NOTE: make sure the snapshot server is upgraded and re-synced first!
-mkdir ~/grid_indexer_tmp
-cd ~/grid_indexer_tmp
+mkdir -p /mnt/disk/grid_indexer_tmp
+cd /mnt/disk/grid_indexer_tmp
 rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/indexer-testnet-latest.tar.gz .
 tar xvf indexer-testnet-latest.tar.gz
 rm indexer-testnet-latest.tar.gz
 docker stop indexer_db
-rm -r /srv/indexer/*
-mv * /srv/indexer/
+rm -r /mnt/disk/srv/indexer/*
+mv * /mnt/disk/srv/indexer/
 cd "$WD"
 docker compose --env-file .secrets.env --env-file .env up --no-deps -d indexer_db


### PR DESCRIPTION
# Work Done

- adjusted the deployment process so it works with micro VM for flist on tfgrid
- Set tar with pv to get a status of the progress
    - Then we get status from rsync (already happening) and from tar (this PR)
- we print the process to log file, this is used on flist to show a wepage of the progress
- Detail: links for networks are e.g. mainnet, but for qanet it was qa_net, so I updated this too

# Status

- This branch along with the PR on TF-Image for the dashboard suite flist (https://github.com/threefoldtech/tf-images/pull/277) are done as a first version. We can deploy on micro VM running on TFGrid all 4 networks: main, qa, dev, test, with env variables: SEED, DOMAIN and NETWORK

# Detail

- The files are in xz not gzip, despite the gz file extension

# Related Work

- This is in line with the grid stack dashboard suite flist: https://github.com/threefoldtech/tf-images/pull/277

# References

- Work done with the collaboration of @scottyeager 