### PR TITLE
tfchain-validator: unattended installs, safe re-runs, and secrets hygiene

### DIFF
--- a/apps/prep-env-prereq.sh
+++ b/apps/prep-env-prereq.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-VERSION=1.6.0
+VERSION=1.12.1
 RELEASE=node_exporter-${VERSION}.linux-amd64
 
 sudo apt update && sudo apt upgrade -y

--- a/tfchain-validator-snapshots/devnet/.gitignore
+++ b/tfchain-validator-snapshots/devnet/.gitignore
@@ -1,0 +1,1 @@
+.secrets.env

--- a/tfchain-validator-snapshots/mainnet/.gitignore
+++ b/tfchain-validator-snapshots/mainnet/.gitignore
@@ -1,0 +1,1 @@
+.secrets.env

--- a/tfchain-validator-snapshots/qanet/.gitignore
+++ b/tfchain-validator-snapshots/qanet/.gitignore
@@ -1,0 +1,1 @@
+.secrets.env

--- a/tfchain-validator-snapshots/testnet/.gitignore
+++ b/tfchain-validator-snapshots/testnet/.gitignore
@@ -1,0 +1,1 @@
+.secrets.env

--- a/tfchain-validator/devnet/.gitignore
+++ b/tfchain-validator/devnet/.gitignore
@@ -1,0 +1,1 @@
+.secrets.env

--- a/tfchain-validator/devnet/install-tfchain-validator.sh
+++ b/tfchain-validator/devnet/install-tfchain-validator.sh
@@ -1,44 +1,68 @@
 #/bin/bash
+# Install and start a TFchain devnet validator.
+#
+# Interactive by default. For unattended installs (CI, Terraform, config
+# management) pass -y / --yes, or set ASSUME_YES=1 in the environment.
 
 WD=$(pwd)
 
-# Ask user to make system changes
-while true; do
-read -p "This script will make changes to your Linux installation. Do you want to proceed? (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will proceed.";
-                break;;
-        [nN] ) echo "OK! Exiting the script.";
-                exit;;
-        * ) echo "Your answer is invalid.";;
-esac
+CHAIN_DB="/srv/tfchain/chains/tfchain_devnet/db"
+SNAPSHOT_TMP="/srv/grid_snapshots_tmp"
+SNAPSHOT_FILE="tfchain-devnet-validator-latest.tar.gz"
+SNAPSHOT_URL="rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsdev/$SNAPSHOT_FILE"
+
+ASSUME_YES="${ASSUME_YES:-0}"
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) ASSUME_YES=1 ;;
+    -h|--help)
+      echo "usage: $0 [-y|--yes]"
+      echo "  -y, --yes   assume yes to all questions (unattended install)"
+      echo "  ASSUME_YES=1 in the environment does the same."
+      exit 0 ;;
+  esac
 done
 
-# Ask user to run prerequisites script
-while true; do
-read -p "Do you want to run the prerequisites script? This will prepare your environment to run the TFchain validator. (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will run the prerequisites script.";
-                sh ../../apps/prep-env-prereq.sh
-                break;;
-        [nN] ) echo "OK! Moving to the next step...";
-                break;;
-        * ) echo "Your answer is invalid.";;
-esac
-done
+# Ask a yes/no question, unless we are running unattended.
+confirm() {
+  [ "$ASSUME_YES" = "1" ] && return 0
+  while true; do
+    read -p "$1 (y/n) " yn
+    case $yn in
+      [yY] ) return 0 ;;
+      [nN] ) return 1 ;;
+      * ) echo "Your answer is invalid." ;;
+    esac
+  done
+}
+
+confirm "This script will make changes to your Linux installation. Do you want to proceed?" || {
+  echo "OK! Exiting the script."
+  exit 0
+}
+
+if confirm "Do you want to run the prerequisites script? This will prepare your environment to run the TFchain validator."; then
+  sh ../../apps/prep-env-prereq.sh
+fi
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_devnet/db /srv/grid_snapshots_tmp
+mkdir -p "$CHAIN_DB" "$SNAPSHOT_TMP"
 
-## Download snapshots, extract and remove archives
-cd /srv/grid_snapshots_tmp
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsdev/tfchain-devnet-validator-latest.tar.gz .
-tar -I pigz -xf tfchain-devnet-validator-latest.tar.gz -C /srv/tfchain/chains/tfchain_devnet/db/
-rm tfchain-devnet-validator-latest.tar.gz
+## Download the snapshot and extract it, unless this node already has a chain
+## database — re-running the installer must not destroy a synced node.
+if [ -n "$(ls -A "$CHAIN_DB" 2>/dev/null)" ]; then
+  echo "Chain database already present in $CHAIN_DB, skipping the snapshot restore."
+else
+  cd "$SNAPSHOT_TMP"
+  rsync -Lv --progress --partial "$SNAPSHOT_URL" .
+  tar -I pigz -xf "$SNAPSHOT_FILE" -C "$CHAIN_DB/"
+  rm -f "$SNAPSHOT_FILE"
+fi
 
-## Clean up 
+## Clean up
 cd "$WD"
-rm -r /srv/grid_snapshots_tmp
+rm -rf "$SNAPSHOT_TMP"
 
-## Start Grid backed services with docker-compose
+## Start the validator with docker-compose
 docker compose --env-file .secrets.env --env-file .env up -d

--- a/tfchain-validator/devnet/validator-init.sh
+++ b/tfchain-validator/devnet/validator-init.sh
@@ -1,20 +1,49 @@
 #/bin/bash
-# Script to initiate two compose based container that will insert aura and grandpa key based on the provided TFchain mnemonic
+# Insert the aura and grandpa session keys of a NEW validator, based on the
+# TFchain wallet mnemonic in .secrets.env.
+#
+# Skip this when moving an EXISTING validator to another machine: copy its
+# keystore instead, see the readme.
+#
+# Interactive by default; pass -y / --yes or set ASSUME_YES=1 to run unattended.
 
-# Ask user to make system changes
-while true; do
-read -p "This script requires you to have created a .secrets.env file that contains your TFchain validator wallet mnemonic. Proceed? (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will proceed.";
-                break;;
-        [nN] ) echo "OK! Exiting the script.";
-                exit;;
-        * ) echo "Your answer is invalid.";;
-esac
+ASSUME_YES="${ASSUME_YES:-0}"
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) ASSUME_YES=1 ;;
+    -h|--help)
+      echo "usage: $0 [-y|--yes]"
+      echo "  -y, --yes   assume yes to all questions (unattended install)"
+      echo "  ASSUME_YES=1 in the environment does the same."
+      exit 0 ;;
+  esac
 done
+
+# Ask a yes/no question, unless we are running unattended.
+confirm() {
+  [ "$ASSUME_YES" = "1" ] && return 0
+  while true; do
+    read -p "$1 (y/n) " yn
+    case $yn in
+      [yY] ) return 0 ;;
+      [nN] ) return 1 ;;
+      * ) echo "Your answer is invalid." ;;
+    esac
+  done
+}
+
+confirm "This script requires you to have created a .secrets.env file that contains your TFchain validator wallet mnemonic. Proceed?" || {
+  echo "OK! Exiting the script."
+  exit 0
+}
 
 ## Create directories
 mkdir -p /srv/tfchain/
 
-## Start Grid backed services with docker-compose
-docker compose --env-file .secrets.env --env-file .env -f validator-init.yml up -d
+## Insert the keys
+docker compose --env-file .secrets.env --env-file .env -f validator-init.yml up
+
+echo
+echo "Keys inserted. Remove the MNEMONIC line from .secrets.env now — it is not"
+echo "needed to run the validator."

--- a/tfchain-validator/mainnet/.gitignore
+++ b/tfchain-validator/mainnet/.gitignore
@@ -1,0 +1,1 @@
+.secrets.env

--- a/tfchain-validator/mainnet/install-tfchain-validator.sh
+++ b/tfchain-validator/mainnet/install-tfchain-validator.sh
@@ -1,44 +1,68 @@
 #/bin/bash
+# Install and start a TFchain mainnet validator.
+#
+# Interactive by default. For unattended installs (CI, Terraform, config
+# management) pass -y / --yes, or set ASSUME_YES=1 in the environment.
 
 WD=$(pwd)
 
-# Ask user to make system changes
-while true; do
-read -p "This script will make changes to your Linux installation. Do you want to proceed? (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will proceed.";
-                break;;
-        [nN] ) echo "OK! Exiting the script.";
-                exit;;
-        * ) echo "Your answer is invalid.";;
-esac
+CHAIN_DB="/srv/tfchain/chains/tfchain_mainnet/db"
+SNAPSHOT_TMP="/srv/grid_snapshots_tmp"
+SNAPSHOT_FILE="tfchain-mainnet-validator-latest.tar.gz"
+SNAPSHOT_URL="rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/$SNAPSHOT_FILE"
+
+ASSUME_YES="${ASSUME_YES:-0}"
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) ASSUME_YES=1 ;;
+    -h|--help)
+      echo "usage: $0 [-y|--yes]"
+      echo "  -y, --yes   assume yes to all questions (unattended install)"
+      echo "  ASSUME_YES=1 in the environment does the same."
+      exit 0 ;;
+  esac
 done
 
-# Ask user to run prerequisites script
-while true; do
-read -p "Do you want to run the prerequisites script? This will prepare your environment to run the TFchain validator. (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will run the prerequisites script.";
-                sh ../../apps/prep-env-prereq.sh
-                break;;
-        [nN] ) echo "OK! Moving to the next step...";
-                break;;
-        * ) echo "Your answer is invalid.";;
-esac
-done
+# Ask a yes/no question, unless we are running unattended.
+confirm() {
+  [ "$ASSUME_YES" = "1" ] && return 0
+  while true; do
+    read -p "$1 (y/n) " yn
+    case $yn in
+      [yY] ) return 0 ;;
+      [nN] ) return 1 ;;
+      * ) echo "Your answer is invalid." ;;
+    esac
+  done
+}
+
+confirm "This script will make changes to your Linux installation. Do you want to proceed?" || {
+  echo "OK! Exiting the script."
+  exit 0
+}
+
+if confirm "Do you want to run the prerequisites script? This will prepare your environment to run the TFchain validator."; then
+  sh ../../apps/prep-env-prereq.sh
+fi
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_mainnet/db ~/grid_snapshots_tmp
+mkdir -p "$CHAIN_DB" "$SNAPSHOT_TMP"
 
-## Download snapshots, extract and remove archives
-cd ~/grid_snapshots_tmp
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshots/tfchain-mainnet-validator-latest.tar.gz .
-tar -I pigz -xf tfchain-mainnet-validator-latest.tar.gz -C /srv/tfchain/chains/tfchain_mainnet/db/
-rm tfchain-mainnet-validator-latest.tar.gz
+## Download the snapshot and extract it, unless this node already has a chain
+## database — re-running the installer must not destroy a synced node.
+if [ -n "$(ls -A "$CHAIN_DB" 2>/dev/null)" ]; then
+  echo "Chain database already present in $CHAIN_DB, skipping the snapshot restore."
+else
+  cd "$SNAPSHOT_TMP"
+  rsync -Lv --progress --partial "$SNAPSHOT_URL" .
+  tar -I pigz -xf "$SNAPSHOT_FILE" -C "$CHAIN_DB/"
+  rm -f "$SNAPSHOT_FILE"
+fi
 
-## Clean up 
+## Clean up
 cd "$WD"
-rm -r ~/grid_snapshots_tmp
+rm -rf "$SNAPSHOT_TMP"
 
-## Start Grid backed services with docker-compose
+## Start the validator with docker-compose
 docker compose --env-file .secrets.env --env-file .env up -d

--- a/tfchain-validator/mainnet/validator-init.sh
+++ b/tfchain-validator/mainnet/validator-init.sh
@@ -1,20 +1,49 @@
 #/bin/bash
-# Script to initiate two compose based container that will insert aura and grandpa key based on the provided TFchain mnemonic
+# Insert the aura and grandpa session keys of a NEW validator, based on the
+# TFchain wallet mnemonic in .secrets.env.
+#
+# Skip this when moving an EXISTING validator to another machine: copy its
+# keystore instead, see the readme.
+#
+# Interactive by default; pass -y / --yes or set ASSUME_YES=1 to run unattended.
 
-# Ask user to make system changes
-while true; do
-read -p "This script requires you to have created a .secrets.env file that contains your TFchain validator wallet mnemonic. Proceed? (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will proceed.";
-                break;;
-        [nN] ) echo "OK! Exiting the script.";
-                exit;;
-        * ) echo "Your answer is invalid.";;
-esac
+ASSUME_YES="${ASSUME_YES:-0}"
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) ASSUME_YES=1 ;;
+    -h|--help)
+      echo "usage: $0 [-y|--yes]"
+      echo "  -y, --yes   assume yes to all questions (unattended install)"
+      echo "  ASSUME_YES=1 in the environment does the same."
+      exit 0 ;;
+  esac
 done
+
+# Ask a yes/no question, unless we are running unattended.
+confirm() {
+  [ "$ASSUME_YES" = "1" ] && return 0
+  while true; do
+    read -p "$1 (y/n) " yn
+    case $yn in
+      [yY] ) return 0 ;;
+      [nN] ) return 1 ;;
+      * ) echo "Your answer is invalid." ;;
+    esac
+  done
+}
+
+confirm "This script requires you to have created a .secrets.env file that contains your TFchain validator wallet mnemonic. Proceed?" || {
+  echo "OK! Exiting the script."
+  exit 0
+}
 
 ## Create directories
 mkdir -p /srv/tfchain/
 
-## Start Grid backed services with docker-compose
-docker compose --env-file .secrets.env --env-file .env -f validator-init.yml up -d
+## Insert the keys
+docker compose --env-file .secrets.env --env-file .env -f validator-init.yml up
+
+echo
+echo "Keys inserted. Remove the MNEMONIC line from .secrets.env now — it is not"
+echo "needed to run the validator."

--- a/tfchain-validator/qanet/.gitignore
+++ b/tfchain-validator/qanet/.gitignore
@@ -1,0 +1,1 @@
+.secrets.env

--- a/tfchain-validator/qanet/install-tfchain-validator.sh
+++ b/tfchain-validator/qanet/install-tfchain-validator.sh
@@ -1,44 +1,68 @@
 #/bin/bash
+# Install and start a TFchain qanet validator.
+#
+# Interactive by default. For unattended installs (CI, Terraform, config
+# management) pass -y / --yes, or set ASSUME_YES=1 in the environment.
 
 WD=$(pwd)
 
-# Ask user to make system changes
-while true; do
-read -p "This script will make changes to your Linux installation. Do you want to proceed? (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will proceed.";
-                break;;
-        [nN] ) echo "OK! Exiting the script.";
-                exit;;
-        * ) echo "Your answer is invalid.";;
-esac
+CHAIN_DB="/srv/tfchain/chains/tfchain_qa_net/db"
+SNAPSHOT_TMP="/srv/grid_snapshots_tmp"
+SNAPSHOT_FILE="tfchain-qanet-validator-latest.tar.gz"
+SNAPSHOT_URL="rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsqa/$SNAPSHOT_FILE"
+
+ASSUME_YES="${ASSUME_YES:-0}"
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) ASSUME_YES=1 ;;
+    -h|--help)
+      echo "usage: $0 [-y|--yes]"
+      echo "  -y, --yes   assume yes to all questions (unattended install)"
+      echo "  ASSUME_YES=1 in the environment does the same."
+      exit 0 ;;
+  esac
 done
 
-# Ask user to run prerequisites script
-while true; do
-read -p "Do you want to run the prerequisites script? This will prepare your environment to run the TFchain validator. (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will run the prerequisites script.";
-                sh ../../apps/prep-env-prereq.sh
-                break;;
-        [nN] ) echo "OK! Moving to the next step...";
-                break;;
-        * ) echo "Your answer is invalid.";;
-esac
-done
+# Ask a yes/no question, unless we are running unattended.
+confirm() {
+  [ "$ASSUME_YES" = "1" ] && return 0
+  while true; do
+    read -p "$1 (y/n) " yn
+    case $yn in
+      [yY] ) return 0 ;;
+      [nN] ) return 1 ;;
+      * ) echo "Your answer is invalid." ;;
+    esac
+  done
+}
+
+confirm "This script will make changes to your Linux installation. Do you want to proceed?" || {
+  echo "OK! Exiting the script."
+  exit 0
+}
+
+if confirm "Do you want to run the prerequisites script? This will prepare your environment to run the TFchain validator."; then
+  sh ../../apps/prep-env-prereq.sh
+fi
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_qa_net/db ~/grid_snapshots_tmp
+mkdir -p "$CHAIN_DB" "$SNAPSHOT_TMP"
 
-## Download snapshots, extract and remove archives
-cd ~/grid_snapshots_tmp
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotsqa/tfchain-qanet-validator-latest.tar.gz .
-tar -I pigz -xf tfchain-qanet-validator-latest.tar.gz -C /srv/tfchain/chains/tfchain_qa_net/db
-rm tfchain-qanet-validator-latest.tar.gz
+## Download the snapshot and extract it, unless this node already has a chain
+## database — re-running the installer must not destroy a synced node.
+if [ -n "$(ls -A "$CHAIN_DB" 2>/dev/null)" ]; then
+  echo "Chain database already present in $CHAIN_DB, skipping the snapshot restore."
+else
+  cd "$SNAPSHOT_TMP"
+  rsync -Lv --progress --partial "$SNAPSHOT_URL" .
+  tar -I pigz -xf "$SNAPSHOT_FILE" -C "$CHAIN_DB/"
+  rm -f "$SNAPSHOT_FILE"
+fi
 
-## Clean up 
+## Clean up
 cd "$WD"
-rm -r ~/grid_snapshots_tmp
+rm -rf "$SNAPSHOT_TMP"
 
-## Start Grid backed services with docker-compose
+## Start the validator with docker-compose
 docker compose --env-file .secrets.env --env-file .env up -d

--- a/tfchain-validator/qanet/validator-init.sh
+++ b/tfchain-validator/qanet/validator-init.sh
@@ -1,20 +1,49 @@
 #/bin/bash
-# Script to initiate two compose based container that will insert aura and grandpa key based on the provided TFchain mnemonic
+# Insert the aura and grandpa session keys of a NEW validator, based on the
+# TFchain wallet mnemonic in .secrets.env.
+#
+# Skip this when moving an EXISTING validator to another machine: copy its
+# keystore instead, see the readme.
+#
+# Interactive by default; pass -y / --yes or set ASSUME_YES=1 to run unattended.
 
-# Ask user to make system changes
-while true; do
-read -p "This script requires you to have created a .secrets.env file that contains your TFchain validator wallet mnemonic. Proceed? (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will proceed.";
-                break;;
-        [nN] ) echo "OK! Exiting the script.";
-                exit;;
-        * ) echo "Your answer is invalid.";;
-esac
+ASSUME_YES="${ASSUME_YES:-0}"
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) ASSUME_YES=1 ;;
+    -h|--help)
+      echo "usage: $0 [-y|--yes]"
+      echo "  -y, --yes   assume yes to all questions (unattended install)"
+      echo "  ASSUME_YES=1 in the environment does the same."
+      exit 0 ;;
+  esac
 done
+
+# Ask a yes/no question, unless we are running unattended.
+confirm() {
+  [ "$ASSUME_YES" = "1" ] && return 0
+  while true; do
+    read -p "$1 (y/n) " yn
+    case $yn in
+      [yY] ) return 0 ;;
+      [nN] ) return 1 ;;
+      * ) echo "Your answer is invalid." ;;
+    esac
+  done
+}
+
+confirm "This script requires you to have created a .secrets.env file that contains your TFchain validator wallet mnemonic. Proceed?" || {
+  echo "OK! Exiting the script."
+  exit 0
+}
 
 ## Create directories
 mkdir -p /srv/tfchain/
 
-## Start Grid backed services with docker-compose
-docker compose --env-file .secrets.env --env-file .env -f validator-init.yml up -d
+## Insert the keys
+docker compose --env-file .secrets.env --env-file .env -f validator-init.yml up
+
+echo
+echo "Keys inserted. Remove the MNEMONIC line from .secrets.env now — it is not"
+echo "needed to run the validator."

--- a/tfchain-validator/readme.md
+++ b/tfchain-validator/readme.md
@@ -216,6 +216,17 @@ Once all prerequisites have been met, start the validator.
 sh install-tfchain-validator.sh
 ```
 
+Both scripts ask for confirmation before changing anything. To run them
+unattended (CI, Terraform, config management), pass `-y` or set `ASSUME_YES=1`:
+
+```sh
+sh validator-init.sh -y
+ASSUME_YES=1 sh install-tfchain-validator.sh
+```
+
+The installer skips the snapshot restore when the node already has a chain
+database, so it is safe to re-run on a synced validator.
+
 Check the logs by starting the provided script.
 ```sh
 sh open_logs_tmux.sh
@@ -278,6 +289,79 @@ Once your session keys are set and the council approves your validator, your nod
 
 - Keep your node online and synchronized.
 - Monitor logs for any errors or warnings.
+
+## Moving an existing validator to another machine
+
+Replacing the hardware under a validator that is already registered on chain is
+**not** the same as adding one: its session keys are already set, so steps 1, 3
+and 4 above do not apply and no council motion is needed.
+
+1. **Stop the old node first.** Running the same session keys on two nodes at
+   once is equivocation:
+   ```sh
+   docker compose --env-file .secrets.env --env-file .env down
+   ```
+2. Copy the keystore off the old machine — two small files, aura (`61757261…`)
+   and grandpa (`6772616e…`):
+   ```
+   /srv/tfchain/chains/<chain>/keystore/
+   ```
+3. On the new machine, set the SAME `TFCHAIN_NODE_KEY` and `NODE_NAME` in
+   `.secrets.env` and leave `MNEMONIC` empty — no key insertion is needed.
+4. Run `install-tfchain-validator.sh`, then place the two keystore files in
+   `/srv/tfchain/chains/<chain>/keystore/` (mode 600, owned by root) and
+   restart the container.
+
+The node resumes authoring with its existing identity. Verify with
+`🎁 Prepared block for proposing` in the logs — importing blocks alone only
+proves that it syncs.
+
+## Container log rotation
+
+The validator is a chatty process. If container logs are not capped, they fill
+the disk and take the node down. Set the caps in `/etc/docker/daemon.json`
+**before** creating the container — `log-opts` only apply to containers created
+afterwards, so an existing stack needs `docker compose up -d --force-recreate`
+to pick them up:
+
+```json
+{
+    "log-opts": {
+        "max-size": "100m",
+        "max-file": "3"
+    }
+}
+```
+
+This applies to logging plugins too: an uncapped plugin cache under
+`/var/lib/docker/plugins/` grows without limit.
+
+## Running in a VM whose root filesystem cannot host container storage
+
+Some VM images (for example ThreeFold Grid full VMs) boot on a root filesystem
+that does not allow `mknod`. Docker cannot extract images there — layer
+extraction converts whiteout files into character devices and fails:
+
+```
+failed to convert whiteout file "usr/share/.wh.man": operation not permitted
+```
+
+Put container storage on an attached block device instead. Note that recent
+Docker releases keep images in the containerd image store, so moving Docker's
+`data-root` alone is not enough — containerd's `root` has to move as well:
+
+```bash
+systemctl stop docker docker.socket containerd
+mkdir -p /mnt/data/docker /mnt/data/containerd
+rsync -aHAX /var/lib/docker/ /mnt/data/docker/
+rsync -aHAX /var/lib/containerd/ /mnt/data/containerd/
+# /etc/docker/daemon.json  ->  "data-root": "/mnt/data/docker"
+sed -i 's|^root = .*|root = "/mnt/data/containerd"|' /etc/containerd/config.toml
+systemctl start containerd && systemctl start docker
+docker info --format '{{.DockerRootDir}}'    # verify before continuing
+```
+
+The chain database should live on that disk as well.
 
 ## References
 

--- a/tfchain-validator/testnet/.gitignore
+++ b/tfchain-validator/testnet/.gitignore
@@ -1,0 +1,1 @@
+.secrets.env

--- a/tfchain-validator/testnet/install-tfchain-validator.sh
+++ b/tfchain-validator/testnet/install-tfchain-validator.sh
@@ -1,44 +1,68 @@
 #/bin/bash
+# Install and start a TFchain testnet validator.
+#
+# Interactive by default. For unattended installs (CI, Terraform, config
+# management) pass -y / --yes, or set ASSUME_YES=1 in the environment.
 
 WD=$(pwd)
 
-# Ask user to make system changes
-while true; do
-read -p "This script will make changes to your Linux installation. Do you want to proceed? (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will proceed.";
-                break;;
-        [nN] ) echo "OK! Exiting the script.";
-                exit;;
-        * ) echo "Your answer is invalid.";;
-esac
+CHAIN_DB="/srv/tfchain/chains/tfchain_testnet/db"
+SNAPSHOT_TMP="/srv/grid_snapshots_tmp"
+SNAPSHOT_FILE="tfchain-testnet-validator-latest.tar.gz"
+SNAPSHOT_URL="rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/$SNAPSHOT_FILE"
+
+ASSUME_YES="${ASSUME_YES:-0}"
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) ASSUME_YES=1 ;;
+    -h|--help)
+      echo "usage: $0 [-y|--yes]"
+      echo "  -y, --yes   assume yes to all questions (unattended install)"
+      echo "  ASSUME_YES=1 in the environment does the same."
+      exit 0 ;;
+  esac
 done
 
-# Ask user to run prerequisites script
-while true; do
-read -p "Do you want to run the prerequisites script? This will prepare your environment to run the TFchain validator. (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will run the prerequisites script.";
-                sh ../../apps/prep-env-prereq.sh
-                break;;
-        [nN] ) echo "OK! Moving to the next step...";
-                break;;
-        * ) echo "Your answer is invalid.";;
-esac
-done
+# Ask a yes/no question, unless we are running unattended.
+confirm() {
+  [ "$ASSUME_YES" = "1" ] && return 0
+  while true; do
+    read -p "$1 (y/n) " yn
+    case $yn in
+      [yY] ) return 0 ;;
+      [nN] ) return 1 ;;
+      * ) echo "Your answer is invalid." ;;
+    esac
+  done
+}
+
+confirm "This script will make changes to your Linux installation. Do you want to proceed?" || {
+  echo "OK! Exiting the script."
+  exit 0
+}
+
+if confirm "Do you want to run the prerequisites script? This will prepare your environment to run the TFchain validator."; then
+  sh ../../apps/prep-env-prereq.sh
+fi
 
 ## Create directories
-mkdir -p /srv/tfchain/chains/tfchain_testnet/db ~/grid_snapshots_tmp
+mkdir -p "$CHAIN_DB" "$SNAPSHOT_TMP"
 
-## Download snapshots, extract and remove archives
-cd ~/grid_snapshots_tmp
-rsync -Lv --progress --partial rsync://bknd.snapshot.grid.tf:34873/gridsnapshotstest/tfchain-testnet-validator-latest.tar.gz .
-tar -I pigz -xf tfchain-testnet-validator-latest.tar.gz -C /srv/tfchain/chains/tfchain_testnet/db
-rm tfchain-testnet-validator-latest.tar.gz
+## Download the snapshot and extract it, unless this node already has a chain
+## database — re-running the installer must not destroy a synced node.
+if [ -n "$(ls -A "$CHAIN_DB" 2>/dev/null)" ]; then
+  echo "Chain database already present in $CHAIN_DB, skipping the snapshot restore."
+else
+  cd "$SNAPSHOT_TMP"
+  rsync -Lv --progress --partial "$SNAPSHOT_URL" .
+  tar -I pigz -xf "$SNAPSHOT_FILE" -C "$CHAIN_DB/"
+  rm -f "$SNAPSHOT_FILE"
+fi
 
-## Clean up 
+## Clean up
 cd "$WD"
-rm -r ~/grid_snapshots_tmp
+rm -rf "$SNAPSHOT_TMP"
 
-## Start Grid backed services with docker-compose
+## Start the validator with docker-compose
 docker compose --env-file .secrets.env --env-file .env up -d

--- a/tfchain-validator/testnet/validator-init.sh
+++ b/tfchain-validator/testnet/validator-init.sh
@@ -1,20 +1,49 @@
 #/bin/bash
-# Script to initiate two compose based container that will insert aura and grandpa key based on the provided TFchain mnemonic
+# Insert the aura and grandpa session keys of a NEW validator, based on the
+# TFchain wallet mnemonic in .secrets.env.
+#
+# Skip this when moving an EXISTING validator to another machine: copy its
+# keystore instead, see the readme.
+#
+# Interactive by default; pass -y / --yes or set ASSUME_YES=1 to run unattended.
 
-# Ask user to make system changes
-while true; do
-read -p "This script requires you to have created a .secrets.env file that contains your TFchain validator wallet mnemonic. Proceed? (y/n) " yn
-case $yn in 
-        [yY] ) echo "OK! We will proceed.";
-                break;;
-        [nN] ) echo "OK! Exiting the script.";
-                exit;;
-        * ) echo "Your answer is invalid.";;
-esac
+ASSUME_YES="${ASSUME_YES:-0}"
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) ASSUME_YES=1 ;;
+    -h|--help)
+      echo "usage: $0 [-y|--yes]"
+      echo "  -y, --yes   assume yes to all questions (unattended install)"
+      echo "  ASSUME_YES=1 in the environment does the same."
+      exit 0 ;;
+  esac
 done
+
+# Ask a yes/no question, unless we are running unattended.
+confirm() {
+  [ "$ASSUME_YES" = "1" ] && return 0
+  while true; do
+    read -p "$1 (y/n) " yn
+    case $yn in
+      [yY] ) return 0 ;;
+      [nN] ) return 1 ;;
+      * ) echo "Your answer is invalid." ;;
+    esac
+  done
+}
+
+confirm "This script requires you to have created a .secrets.env file that contains your TFchain validator wallet mnemonic. Proceed?" || {
+  echo "OK! Exiting the script."
+  exit 0
+}
 
 ## Create directories
 mkdir -p /srv/tfchain/
 
-## Start Grid backed services with docker-compose
-docker compose --env-file .secrets.env --env-file .env -f validator-init.yml up -d
+## Insert the keys
+docker compose --env-file .secrets.env --env-file .env -f validator-init.yml up
+
+echo
+echo "Keys inserted. Remove the MNEMONIC line from .secrets.env now — it is not"
+echo "needed to run the validator."


### PR DESCRIPTION
While moving a validator to new hardware and provisioning a few more from
Terraform, I ran into a handful of rough edges in `tfchain-validator/`. All of
these are things that bit me for real:

**Secrets hygiene.** `tfchain-validator/` and `tfchain-validator-snapshots/`
are the only components without a `.gitignore` for `.secrets.env` — and they
are the ones whose `.secrets.env` holds the node key and the validator wallet
mnemonic. Following the readme leaves that file inside the clone, one
`git add -A` away from being committed. Added the same `.gitignore` the other
components already have.

**Unattended installs.** `install-tfchain-validator.sh` and
`validator-init.sh` block on `read`, so they can't be driven from CI,
Terraform or config management. They now accept `-y`/`--yes` (or
`ASSUME_YES=1`) and are unchanged when run by hand.

**Re-running the installer could destroy a synced node.** The snapshot restore
ran unconditionally and extracted over the existing database. It now skips the
restore when the chain database is already populated.

**Snapshot download location.** qanet, testnet and mainnet downloaded the
archive into the home directory, i.e. the root filesystem; devnet used `/srv`.
The mainnet snapshot is ~28G compressed, which is enough to fill a root disk.
All four now use `/srv/grid_snapshots_tmp`.

**Smaller bits.** `validator-init.sh` reminds the operator to clear `MNEMONIC`
afterwards, and `prep-env-prereq.sh` installs node_exporter 1.12.1 instead of
1.6.0.

**Readme.** Three additions:

- *Moving an existing validator to another machine* — reusing the keystore and
  node key means no `setKeys` and no council motion, and the old node must be
  stopped first or you are equivocating. That path wasn't documented anywhere.
- *Container log rotation* — uncapped container logs have taken validators
  down for us; `log-opts` only apply to containers created afterwards.
- *Running in a VM whose root filesystem cannot host container storage* — on
  VM images with a virtiofs root, `mknod` is denied and image extraction fails
  on whiteout conversion. Recent Docker keeps images in the containerd image
  store, so moving `data-root` alone isn't enough; containerd's `root` has to
  move too.

No behaviour changes for anyone running the scripts interactively.